### PR TITLE
various fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,2 @@
 *.pyo
 *.rpyc
-*.rpyc
-*.rpyc
-*.rpyc
-*.rpyc
-*.rpyc

--- a/eval_tdomi_katsugame.rpy
+++ b/eval_tdomi_katsugame.rpy
@@ -120,7 +120,8 @@ label eval_katsu_help:
     
     if evalServedCustomers == 7:
         m "Suddenly, I saw Amely run past the stand."
-        show amely smnormal with easeinright
+#        show amely smnormal at Position(xpos=.0, xanchor='right') with easeinright
+        show amely smnormal at Position(xpos=.99, xanchor='left') with easeinright
         hide amely with easeoutleft
         $ renpy.pause (1.0)
         m "Wait. Where did Adine go?"
@@ -197,27 +198,8 @@ label eval_katsu_help_2:
             $ evalQualityServed = 2
 
     m "Katsuharu handed me the cone."
+    return
 
-    if customers[evalServedCustomers] == "8":
-        jump eval_help_8th_2
-    elif customers[evalServedCustomers] == "Dram":
-        jump eval_help_dram_2
-    elif customers[evalServedCustomers] == "Em":
-        jump eval_help_em_2
-    elif customers[evalServedCustomers] == "Grey":
-        jump eval_help_grey_2
-    elif customers[evalServedCustomers] == "Kali":
-        jump eval_help_kali_2
-    elif customers[evalServedCustomers] == "Kev":
-        jump eval_help_kev_2
-    elif customers[evalServedCustomers] == "Ley":
-        jump eval_help_ley_2
-    elif customers[evalServedCustomers] == "Oph":
-        jump eval_help_oph_2
-    elif customers[evalServedCustomers] == "Lucius":
-        jump eval_help_luc_2
-    elif customers[evalServedCustomers] == "Xith":
-        jump eval_help_xith_2
 
 #Character dialogue - I think the dialogue is a bit lackluster at the moment. I should try to give it more character once everyone is done.
 #Oh god this is gonna be a lot of writing - 70 branches of dialogue. Oof.
@@ -244,45 +226,43 @@ label eval_help_8th:
         c "I can relate. What would you like?"
     Ei "Could I get a scoop of strawberry, please?"
     c "Yep. One scoop of strawberry coming right up."
-    jump eval_katsu_help_2
+    call eval_katsu_help_2 from eval_help_8th_2
+    c "Here you are. Enjoy!"
 
-    label eval_help_8th_2:
-        c "Here you are. Enjoy!"
-    
-        if evalCharacterMood == 0:
-            if evalCharacterMood == evalQualityServed:
-                Ei "Ah, thank you! Great service too!"
-                c "Thank you!"
-                $ evalCustomerScore += 1
-            else:
-                Ei "Hm, looks great, but I really need to get going now."
-                c "Of course. Have a nice day."
-        elif evalCharacterMood == 1:
-            if evalCharacterMood == evalQualityServed:
-                Ei "Thank you! This looks amazing!"
-                c "Of course! We took extra care to make this one."
-                Ei "It really shows!"
-                $ evalCustomerScore += 1
-            elif evalQualityServed == 0:
-                Ei "Looks good, but Katsuharu might be losing his magical touch."
-                c "Is everything alright with it?"
-                Ei "Yes. It just looks a bit different from what I remember."
-            else:
-                Ei "This looks amazing, but I doubt I'm going to be able to eat it all!"
+    if evalCharacterMood == 0:
+        if evalCharacterMood == evalQualityServed:
+            Ei "Ah, thank you! Great service too!"
+            c "Thank you!"
+            $ evalCustomerScore += 1
         else:
-            if evalCharacterMood == evalQualityServed:
-                Ei "Wow! That's a lot of delicious looking ice cream! Thanks!"
-                $ evalCustomerScore += 1
-            else:
-                Ei "Thank you, this looks really good! I should have ordered more, though."
-                c "You can order another cone if you like."
-                Ei "It's alright. I don't want to hold up the line any longer."
-        
-        hide 8th with easeoutleft
-        m "With that, he paid and left."
+            Ei "Hm, looks great, but I really need to get going now."
+            c "Of course. Have a nice day."
+    elif evalCharacterMood == 1:
+        if evalCharacterMood == evalQualityServed:
+            Ei "Thank you! This looks amazing!"
+            c "Of course! We took extra care to make this one."
+            Ei "It really shows!"
+            $ evalCustomerScore += 1
+        elif evalQualityServed == 0:
+            Ei "Looks good, but Katsuharu might be losing his magical touch."
+            c "Is everything alright with it?"
+            Ei "Yes. It just looks a bit different from what I remember."
+        else:
+            Ei "This looks amazing, but I doubt I'm going to be able to eat it all!"
+    else:
+        if evalCharacterMood == evalQualityServed:
+            Ei "Wow! That's a lot of delicious looking ice cream! Thanks!"
+            $ evalCustomerScore += 1
+        else:
+            Ei "Thank you, this looks really good! I should have ordered more, though."
+            c "You can order another cone if you like."
+            Ei "It's alright. I don't want to hold up the line any longer."
+    
+    hide 8th with easeoutleft
+    m "With that, he paid and left."
 
-        $ evalServedCustomers += 1
-        jump eval_katsu_help
+    $ evalServedCustomers += 1
+    jump eval_katsu_help
 
 label eval_help_dram: #... dot dot dot ...
     $ evalCharacterPreferredFlavor = "mango"
@@ -333,35 +313,33 @@ label eval_help_dram: #... dot dot dot ...
             Dr "..."
             m "He continued looking at the mango ice cream, drool welling up on his muzzle."
     
-    jump eval_katsu_help_2
-
-    label eval_help_dram_2:
-        c "Here you go..."
+    call eval_katsu_help_2 from eval_help_dram_2
+    c "Here you go..."
+    if persistent.evalSeenDramavian:
+        m "I purposely said the three dots out loud."
+    else:
+        m "I found myself also saying the three dots out loud."
+    
+    if evalCharacterMood == evalQualityServed:
+        Dr "..."
         if persistent.evalSeenDramavian:
-            m "I purposely said the three dots out loud."
-        else:
-            m "I found myself also saying the three dots out loud."
-        
-        if evalCharacterMood == evalQualityServed:
+            Dr "Thanks..."
+            m "I smiled."
+            c "Any time."
             Dr "..."
-            if persistent.evalSeenDramavian:
-                Dr "Thanks..."
-                m "I smiled."
-                c "Any time."
-                Dr "..."
-            
-            $ evalCustomerScore += 1
-        else:
-            Dr "..."
-            if persistent.evalSeenDramavian:
-                Dr "Good..."
-                c "Glad to hear it."
         
-        hide dramavian with easeoutleft
-        m "With that, he paid and left."
+        $ evalCustomerScore += 1
+    else:
+        Dr "..."
+        if persistent.evalSeenDramavian:
+            Dr "Good..."
+            c "Glad to hear it."
+    
+    hide dramavian with easeoutleft
+    m "With that, he paid and left."
 
-        $ evalServedCustomers += 1
-        jump eval_katsu_help
+    $ evalServedCustomers += 1
+    jump eval_katsu_help
 
 label eval_help_em:
     $ evalCharacterPreferredFlavor = "cherry"
@@ -385,50 +363,48 @@ label eval_help_em:
         Em ques "I'll take the cherry please. It is quite a sophisticated flavor if you ask me."
     
     c "One scoop of cherry coming right up!"
-    jump eval_katsu_help_2
+    call eval_katsu_help_2 from eval_help_em_2
+    c "Here you go. Enjoy!"
 
-    label eval_help_em_2:
-        c "Here you go. Enjoy!"
-
-        if evalCharacterMood == 0:
-            if evalCharacterMood == evalQualityServed:
-                Em laugh "Thank's for making it fast. Now I should have plenty of time to make it to the meeting."
-                c "Happy to help."
-                $ evalCustomerScore += 1
-            else:
-                Em frown "Hm, this looks good, but I really have to get going now. This took longer than I expected."
-                c "I understand. Have a nice day."
-        elif evalCharacterMood == 1:
-            if evalCharacterMood == evalQualityServed:
-                Em laugh "Wow, Katsuharu still manages to make his ice cream look absolutely stunning."
-                c "I'm glad too see that you like it."
-                Em normal "Please make sure to tell Katsuharu that."
-                c "I will."
-                $ evalCustomerScore += 1
-            elif evalQualityServed == 0:
-                Em frown "Looks good, but I don't really think it's up to my standards."
-                c "Should I get you another?"
-                Em "Don't bother. This will suffice."
-            else:
-                Em frown "This is a lot of ice cream. Are you implying I look fat?"
-                c "N... No. Of course not! I just thought that a bit of extra ice cream never hurt."
-                if askiffat:
-                    m "So this is how Remy felt earlier."
-                Em normal "I will choose to believe your statement this time, [player_name]."
+    if evalCharacterMood == 0:
+        if evalCharacterMood == evalQualityServed:
+            Em laugh "Thank's for making it fast. Now I should have plenty of time to make it to the meeting."
+            c "Happy to help."
+            $ evalCustomerScore += 1
         else:
-            if evalCharacterMood == evalQualityServed:
-                Em laugh "Wow! That's definitely enough to cool off after that meeting."
-                $ evalCustomerScore += 1
-            else:
-                Em "Thank you, this looks quite good. In hindsight I should have asked for a bit more. That meeting really did a number on me."
-                c "You could order another if you like."
-                Em "It is quite alright. I don't want to anger anyone else behind me."
-        
-        hide emera with easeoutleft
-        m "With that, she paid and left."
+            Em frown "Hm, this looks good, but I really have to get going now. This took longer than I expected."
+            c "I understand. Have a nice day."
+    elif evalCharacterMood == 1:
+        if evalCharacterMood == evalQualityServed:
+            Em laugh "Wow, Katsuharu still manages to make his ice cream look absolutely stunning."
+            c "I'm glad to see that you like it."
+            Em normal "Please make sure to tell Katsuharu that."
+            c "I will."
+            $ evalCustomerScore += 1
+        elif evalQualityServed == 0:
+            Em frown "Looks good, but I don't really think it's up to my standards."
+            c "Should I get you another?"
+            Em "Don't bother. This will suffice."
+        else:
+            Em frown "This is a lot of ice cream. Are you implying I look fat?"
+            c "N... No. Of course not! I just thought that a bit of extra ice cream never hurt."
+            if askiffat:
+                m "So this is how Remy felt earlier."
+            Em normal "I will choose to believe your statement this time, [player_name]."
+    else:
+        if evalCharacterMood == evalQualityServed:
+            Em laugh "Wow! That's definitely enough to cool off after that meeting."
+            $ evalCustomerScore += 1
+        else:
+            Em "Thank you, this looks quite good. In hindsight I should have asked for a bit more. That meeting really did a number on me."
+            c "You could order another if you like."
+            Em "It is quite alright. I don't want to anger anyone else behind me."
+    
+    hide emera with easeoutleft
+    m "With that, she paid and left."
 
-        $ evalServedCustomers += 1
-        jump eval_katsu_help
+    $ evalServedCustomers += 1
+    jump eval_katsu_help
 
 label eval_help_grey:
     $ evalCharacterPreferredFlavor = "vanilla"
@@ -451,69 +427,67 @@ label eval_help_grey:
         Gr "Yes please!"
     
     c "Perfect. Let me get that for you."
-    jump eval_katsu_help_2
+    call eval_katsu_help_2 from eval_help_grey_2
+    c "Here you go!"
 
-    label eval_help_grey_2:
-        c "Here you go!"
-
-        if evalCharacterMood == 0:
-            if evalCharacterMood == evalQualityServed:
-                Gr "Great! Thanks for making it quick!"
-                c "Of course. Didn't want you to be late."
-                Gr "Thank you! This could make or break my career as an artist!"
-                c "I would say good luck, but I doubt you need it."
-                Gr "How so?"
-                c "I think I've seen some of your work. It's magnificent."
-                Gr "Thank you! I should probably get going now."
-                $ evalCustomerScore += 1
-            else:
-                Gr "That looks good. Thanks!"
-                c "No problem."
-                Gr "I should really get going now, this meeting is really important."
-                c "Of course. Good luck!"
-        elif evalCharacterMood == 1:
-            if evalCharacterMood == evalQualityServed:
-                Gr "Wow! I know that Katsuharu puts a lot of time and dedication into his craft, but this is a true work of art."
-                c "Coming from an artist like yourself, I assume we should take that as quite the compliment."
-                Gr "Absolutely!"
-                c "Well, thank you. I'll make sure to tell Katsuharu how much you appreciate his work."
-                Gr "Please do. I should get going before the dragons behind me start getting too angry."
-                c "Good plan. It was nice seeing you again!"
-                Gr "You too!"
-                $ evalCustomerScore += 1
-            elif evalQualityServed == 0:
-                Gr "This doesn't quite look like how it did when I came here before."
-                c "Is everything alright with it?"
-                Gr "Yes. I guess I shouldn't blame Katsuharu. He seems really busy right now, so he probably doesn't have the time to be as careful and precise as he normally is."
-                c "We are quite busy today."
-                Gr "Don't worry, I totally understand. Have a nice day!"
-            else:
-                Gr "This looks great! How am I ever going to eat all of this, though?"
-                c "No worries. I gave you a bit extra, it's on the house."
-                Gr "Oh, thank you! Still, I hate to waste perfectly good ice cream."
-                Gr "Anyways, I best get going. I have an art meeting soon and I should try to get there early."
-                c "Oh course, have a nice day!"
-                Gr "You too!"
+    if evalCharacterMood == 0:
+        if evalCharacterMood == evalQualityServed:
+            Gr "Great! Thanks for making it quick!"
+            c "Of course. Didn't want you to be late."
+            Gr "Thank you! This could make or break my career as an artist!"
+            c "I would say good luck, but I doubt you need it."
+            Gr "How so?"
+            c "I think I've seen some of your work. It's magnificent."
+            Gr "Thank you! I should probably get going now."
+            $ evalCustomerScore += 1
         else:
-            if evalCharacterMood == evalQualityServed:
-                Gr "Wow! That's a lot of ice cream! Perfect to calm the nerves before my art showcase later today."
-                c "Art showcase?"
-                Gr "Yeah! A bunch of the higher ups like Emera are interested in my artwork!"
-                c "That's great! I'm sure they'll love it."
-                Gr "I sure hope so. Have a nice day!"
-                $ evalCustomerScore += 1
-            else:
-                Gr "This looks amazing! I should have ordered more. This might not be enough to calm my nerves before my art showcase later today."
-                c "Art showcase?"
-                Gr "Yeah! A bunch of the higher ups like Emera are interested in my artwork!"
-                c "You could order another cone to calm your nerves."
-                Gr "Don't worry about it. This should be enough, and I don't want to hold up the line any longer."
-        
-        hide grey with easeoutleft
-        m "With that, Grey paid and left."
+            Gr "That looks good. Thanks!"
+            c "No problem."
+            Gr "I should really get going now, this meeting is really important."
+            c "Of course. Good luck!"
+    elif evalCharacterMood == 1:
+        if evalCharacterMood == evalQualityServed:
+            Gr "Wow! I know that Katsuharu puts a lot of time and dedication into his craft, but this is a true work of art."
+            c "Coming from an artist like yourself, I assume we should take that as quite the compliment."
+            Gr "Absolutely!"
+            c "Well, thank you. I'll make sure to tell Katsuharu how much you appreciate his work."
+            Gr "Please do. I should get going before the dragons behind me start getting too angry."
+            c "Good plan. It was nice seeing you again!"
+            Gr "You too!"
+            $ evalCustomerScore += 1
+        elif evalQualityServed == 0:
+            Gr "This doesn't quite look like how it did when I came here before."
+            c "Is everything alright with it?"
+            Gr "Yes. I guess I shouldn't blame Katsuharu. He seems really busy right now, so he probably doesn't have the time to be as careful and precise as he normally is."
+            c "We are quite busy today."
+            Gr "Don't worry, I totally understand. Have a nice day!"
+        else:
+            Gr "This looks great! How am I ever going to eat all of this, though?"
+            c "No worries. I gave you a bit extra, it's on the house."
+            Gr "Oh, thank you! Still, I hate to waste perfectly good ice cream."
+            Gr "Anyways, I best get going. I have an art meeting soon and I should try to get there early."
+            c "Oh course, have a nice day!"
+            Gr "You too!"
+    else:
+        if evalCharacterMood == evalQualityServed:
+            Gr "Wow! That's a lot of ice cream! Perfect to calm the nerves before my art showcase later today."
+            c "Art showcase?"
+            Gr "Yeah! A bunch of the higher ups like Emera are interested in my artwork!"
+            c "That's great! I'm sure they'll love it."
+            Gr "I sure hope so. Have a nice day!"
+            $ evalCustomerScore += 1
+        else:
+            Gr "This looks amazing! I should have ordered more. This might not be enough to calm my nerves before my art showcase later today."
+            c "Art showcase?"
+            Gr "Yeah! A bunch of the higher ups like Emera are interested in my artwork!"
+            c "You could order another cone to calm your nerves."
+            Gr "Don't worry about it. This should be enough, and I don't want to hold up the line any longer."
+    
+    hide grey with easeoutleft
+    m "With that, Grey paid and left."
 
-        $ evalServedCustomers += 1
-        jump eval_katsu_help
+    $ evalServedCustomers += 1
+    jump eval_katsu_help
 
 label eval_help_kali:
     $ evalCharacterPreferredFlavor = "chocolate"
@@ -541,60 +515,58 @@ label eval_help_kali:
         c "Anytime. What can I get you?"
     Kl "I'll take a scoop of chocolate, if you don't mind."
     c "Coming right up!"
-    jump eval_katsu_help_2
+    call eval_katsu_help_2 from eval_help_kali_2
+    c "Here's your chocolate ice cream."
 
-    label eval_help_kali_2:
-        c "Here's your chocolate ice cream."
-
-        if evalCharacterMood == 0:
-            if evalCharacterMood == evalQualityServed:
-                Kl "Perfect! I should probably get going before Bryce throws a fit."
-                c "He is not the kind of dragon I would want to see mad."
-                Kl "It's not pretty, I've seen it before."
-                $ evalCustomerScore += 1
-            else:
-                Kl "Looks wonderful, but I've really got to get going now. Bryce is probably going to throw a fit."
-                c "That doesn't sound pretty."
-                Kl "It's not, I promise."
-        elif evalCharacterMood == 1:
-            if evalCharacterMood == evalQualityServed:
-                Kl "This looks beautiful! Thank you!"
-                c "For all of your hard work on the case I thought spending a bit of extra time to make it perfect was the least we could do."
-                Kl "I appreciate that. It's things like this that make the job worth it."
-                $ evalCustomerScore += 1
-            elif evalQualityServed == 0:
-                Kl "This looks good, [player_name], but Katsuharu might want to slow down a bit."
-                c "Why? Is something wrong?"
-                Kl "Nothing is wrong. It's just a bit sloppier than I'm used to."
-                c "Would you like us to remake it?"
-                Kl "Don't worry about it. I'm sure you guys are under a lot of pressure with the massive amount of customers that have come today, and I don't want to add to that." #Meh, this is a bit sloppy
-                c "I think you're right. I'm really sorry about the ice cream."
-                Kl "Please, don't worry. It's still perfectly good ice cream. It was rude of me to say anything in the first place."
-            else:
-                Kl "This looks magnificent, [player_name]! How am I going to eat all of this?"
-                c "I thought you could use a bit extra to help with all the paperwork."
-                Kl "Maybe you're right."
+    if evalCharacterMood == 0:
+        if evalCharacterMood == evalQualityServed:
+            Kl "Perfect! I should probably get going before Bryce throws a fit."
+            c "He is not the kind of dragon I would want to see mad."
+            Kl "It's not pretty, I've seen it before."
+            $ evalCustomerScore += 1
         else:
-            if evalCharacterMood == evalQualityServed:
-                Kl "That's quite an impressive scoop!"
-                c "I thought you could use a bit of extra ice cream to help you through the monotony of your paperwork."
-                Kl "Oh boy could I ever."
-                $ evalCustomerScore += 1
-            else:
-                Kl "Thank you, [player_name]! This looks really good. In hindsight I probably should have ordered more!"
-                c "You still can if you wish."
-                Kl "Thanks, but I think I'll pass. I've already held up the line, and Bryce is probably going to throw a fit if I don't get back to the office soon."
-                c "Oh. I would go. I don't think that would be pretty."
-                Kl "I've experienced it firsthand. It's not."
-        
-        c "Well, it was nice seeing you."
-        Kl "You too. Maybe we'll meet again."
+            Kl "Looks wonderful, but I've really got to get going now. Bryce is probably going to throw a fit."
+            c "That doesn't sound pretty."
+            Kl "It's not, I promise."
+    elif evalCharacterMood == 1:
+        if evalCharacterMood == evalQualityServed:
+            Kl "This looks beautiful! Thank you!"
+            c "For all of your hard work on the case I thought spending a bit of extra time to make it perfect was the least we could do."
+            Kl "I appreciate that. It's things like this that make the job worth it."
+            $ evalCustomerScore += 1
+        elif evalQualityServed == 0:
+            Kl "This looks good, [player_name], but Katsuharu might want to slow down a bit."
+            c "Why? Is something wrong?"
+            Kl "Nothing is wrong. It's just a bit sloppier than I'm used to."
+            c "Would you like us to remake it?"
+            Kl "Don't worry about it. I'm sure you guys are under a lot of pressure with the massive amount of customers that have come today, and I don't want to add to that." #Meh, this is a bit sloppy
+            c "I think you're right. I'm really sorry about the ice cream."
+            Kl "Please, don't worry. It's still perfectly good ice cream. It was rude of me to say anything in the first place."
+        else:
+            Kl "This looks magnificent, [player_name]! How am I going to eat all of this?"
+            c "I thought you could use a bit extra to help with all the paperwork."
+            Kl "Maybe you're right."
+    else:
+        if evalCharacterMood == evalQualityServed:
+            Kl "That's quite an impressive scoop!"
+            c "I thought you could use a bit of extra ice cream to help you through the monotony of your paperwork."
+            Kl "Oh boy could I ever."
+            $ evalCustomerScore += 1
+        else:
+            Kl "Thank you, [player_name]! This looks really good. In hindsight I probably should have ordered more!"
+            c "You still can if you wish."
+            Kl "Thanks, but I think I'll pass. I've already held up the line, and Bryce is probably going to throw a fit if I don't get back to the office soon."
+            c "Oh. I would go. I don't think that would be pretty."
+            Kl "I've experienced it firsthand. It's not."
+    
+    c "Well, it was nice seeing you."
+    Kl "You too. Maybe we'll meet again."
 
-        hide kalinth with easeoutleft
-        m "With that, she paid and left."
+    hide kalinth with easeoutleft
+    m "With that, she paid and left."
 
-        $ evalServedCustomers += 1
-        jump eval_katsu_help
+    $ evalServedCustomers += 1
+    jump eval_katsu_help
 
 #OHHHHH WE'RE HALFWAY THEREEEEE *AHHHH* *AHHH* THIS IS SO TE-DI-OUS!!!
 
@@ -651,61 +623,59 @@ label eval_help_kev:
             c "Maybe. Anyways, what flavor would you like?"
     Kv ramble "I'll take a scoop of chocolate, please."
     c "On it!"
-    jump eval_katsu_help_2
+    call eval_katsu_help_2 from eval_help_kev_2
+    c "Here you go."
 
-    label eval_help_kev_2:
-        c "Here you go."
-
-        if evalCharacterMood == 0:
-            if evalCharacterMood == evalQualityServed:
-                Kv normal "Thanks for making it quick, I've really got to go."
-                if not kevinunplayed:
-                    c "Go do me proud and give out those flyers."
-                    Kv face "I'll do it for you, [player_name], but only you"
-                    show kevin normal with dissolvemed
-                else:
-                    c "Of course. Have a nice day!"
-                $ evalCustomerScore += 1
-            else:
-                Kv normal "That took a little bit! I might be late if I don't go..."
-                m "Kevin looked at his wrist where one would normally wear a watch."
-                Kv face "Right now! I'm probably late! Thank you! Bye!"
+    if evalCharacterMood == 0:
+        if evalCharacterMood == evalQualityServed:
+            Kv normal "Thanks for making it quick, I've really got to go."
+            if not kevinunplayed:
+                c "Go do me proud and give out those flyers."
+                Kv face "I'll do it for you, [player_name], but only you"
                 show kevin normal with dissolvemed
-        elif evalCharacterMood == 1:
-            if evalCharacterMood == evalQualityServed:
-                Kv normal "Wow! This looks spectacular! You can really tell that Katsuharu cares about his craft."
-                c "I'll make sure to put in a good word on your behalf."
-                Kv "Please do!"
-                $ evalCustomerScore += 1
-            elif evalQualityServed == 0:
-                Kv normal "That was fast, maybe even a little too fast."
-                c "Is everything alright?"
-                Kv face "Yes. I shouldn't have said anything at all. That was quite rude."
-                Kv normal "Normally, Katsuharu spends a lot of time making his ice cream look perfect."
-                Kv "But with the line, I can excuse the sloppiness."
-                c "I could get you another if you wish."
-                Kv "Please, don't worry about it. I don't want to hold up the line any longer. And it's not like presentation makes the actual ice cream any worse!"
             else:
-                Kv normal "Wow, that's a lot of ice cream! I'm not even sure I can eat all of this!"
+                c "Of course. Have a nice day!"
+            $ evalCustomerScore += 1
         else:
-            if evalCharacterMood == evalQualityServed:
-                Kv normal "Wow! That's a ton of ice cream. Thanks!"
-                c "I thought you could use a bit extra after a busy day."
-                Kv ramble "Boy could I ever."
-                show kevin normal with dissolvemed
-                $ evalCustomerScore += 1
-            else:
-                Kv normal "Thank you, this looks great! In hindsight, I should have ordered a bit more."
-                Kv "Giving out flyers is hard work, y'know?"
-                c "You could always order more now."
-                Kv "I don't want to hold up the line and get anyone in line too angry. Those are potential college-goers!"
-                m "A real one track mind it seems."
-        
-        hide kevin with easeoutleft
-        m "With that, he paid and left."
+            Kv normal "That took a little bit! I might be late if I don't go..."
+            m "Kevin looked at his wrist where one would normally wear a watch."
+            Kv face "Right now! I'm probably late! Thank you! Bye!"
+            show kevin normal with dissolvemed
+    elif evalCharacterMood == 1:
+        if evalCharacterMood == evalQualityServed:
+            Kv normal "Wow! This looks spectacular! You can really tell that Katsuharu cares about his craft."
+            c "I'll make sure to put in a good word on your behalf."
+            Kv "Please do!"
+            $ evalCustomerScore += 1
+        elif evalQualityServed == 0:
+            Kv normal "That was fast, maybe even a little too fast."
+            c "Is everything alright?"
+            Kv face "Yes. I shouldn't have said anything at all. That was quite rude."
+            Kv normal "Normally, Katsuharu spends a lot of time making his ice cream look perfect."
+            Kv "But with the line, I can excuse the sloppiness."
+            c "I could get you another if you wish."
+            Kv "Please, don't worry about it. I don't want to hold up the line any longer. And it's not like presentation makes the actual ice cream any worse!"
+        else:
+            Kv normal "Wow, that's a lot of ice cream! I'm not even sure I can eat all of this!"
+    else:
+        if evalCharacterMood == evalQualityServed:
+            Kv normal "Wow! That's a ton of ice cream. Thanks!"
+            c "I thought you could use a bit extra after a busy day."
+            Kv ramble "Boy could I ever."
+            show kevin normal with dissolvemed
+            $ evalCustomerScore += 1
+        else:
+            Kv normal "Thank you, this looks great! In hindsight, I should have ordered a bit more."
+            Kv "Giving out flyers is hard work, y'know?"
+            c "You could always order more now."
+            Kv "I don't want to hold up the line and get anyone in line too angry. Those are potential college-goers!"
+            m "A real one track mind it seems."
+    
+    hide kevin with easeoutleft
+    m "With that, he paid and left."
 
-        $ evalServedCustomers += 1
-        jump eval_katsu_help
+    $ evalServedCustomers += 1
+    jump eval_katsu_help
 
 label eval_help_ley: #Ask for a tape measure for poking Adine
     $ evalCharacterPreferredFlavor = "mango"
@@ -733,49 +703,47 @@ label eval_help_ley: #Ask for a tape measure for poking Adine
     Le "I'm thinking that the mango sounds good right now."
     c "It matches your hard hat quite nicely."
     Le "Thanks?"
-    jump eval_katsu_help_2
+    call eval_katsu_help_2 from eval_help_ley_2
+    c "Here's your mango ice cream!"
 
-    label eval_help_ley_2:
-        c "Here's your mango ice cream!"
-
-        if evalCharacterMood == 0:
-            if evalCharacterMood == evalQualityServed:
-                Le "Nice and quick! Thanks, [player_name]!"
-                c "Can't have your colleagues getting angry at you."
-                Le "Thanks for looking out for me."
-                $ evalCustomerScore += 1
-            else:
-                Le "Thank you. It looks wonderful, but I've really got to get going now."
-                c "I understand. See you around hopefully."
-                m "The dragon muttered something about his colleagues being unhappy." #Meh, might want to change this
-        elif evalCharacterMood == 1:
-            if evalCharacterMood == evalQualityServed:
-                Le "Wow, this looks so good, I don't know if I even want to eat it!"
-                c "Well, if you don't eat it, the sun will make quick work of it instead."
-                Le "Good point."
-                Le "Have a nice day, [player_name]!"
-                $ evalCustomerScore += 1
-            elif evalQualityServed == 0:
-                Le "This looks delicious! Although I recall the ice cream looking more presentable in the past."
-                c "Is it alright? I can always get you another."
-                Le "Please, don't bother. It's still perfectly good ice cream, and I really shouldn't be holding up the line any longer."
-            else:
-                Le "That's quite the amount of mango ice cream you have there, [player_name]!"
-                Le "How am I even supposed to eat all of that?"
-                c "I thought you could use a bit extra. It's a little warm today."
-                Le "I guess so. Thanks!"
+    if evalCharacterMood == 0:
+        if evalCharacterMood == evalQualityServed:
+            Le "Nice and quick! Thanks, [player_name]!"
+            c "Can't have your colleagues getting angry at you."
+            Le "Thanks for looking out for me."
+            $ evalCustomerScore += 1
         else:
-            if evalCharacterMood == evalQualityServed:
-                Le "That's a lot of mango ice cream, [player_name]!"
-                c "You said you were hungry, so I added a bit extra."
-                Le "Thanks a ton! I really needed some extra ice cream today!"
-                $ evalCustomerScore += 1
-        
-        hide leymas with easeoutleft #Add a bit more here possibly. Idk why I like leymas more than the other characters I made up
-        m "With that, Leymas paid and left."
+            Le "Thank you. It looks wonderful, but I've really got to get going now."
+            c "I understand. See you around hopefully."
+            m "The dragon muttered something about his colleagues being unhappy." #Meh, might want to change this
+    elif evalCharacterMood == 1:
+        if evalCharacterMood == evalQualityServed:
+            Le "Wow, this looks so good, I don't know if I even want to eat it!"
+            c "Well, if you don't eat it, the sun will make quick work of it instead."
+            Le "Good point."
+            Le "Have a nice day, [player_name]!"
+            $ evalCustomerScore += 1
+        elif evalQualityServed == 0:
+            Le "This looks delicious! Although I recall the ice cream looking more presentable in the past."
+            c "Is it alright? I can always get you another."
+            Le "Please, don't bother. It's still perfectly good ice cream, and I really shouldn't be holding up the line any longer."
+        else:
+            Le "That's quite the amount of mango ice cream you have there, [player_name]!"
+            Le "How am I even supposed to eat all of that?"
+            c "I thought you could use a bit extra. It's a little warm today."
+            Le "I guess so. Thanks!"
+    else:
+        if evalCharacterMood == evalQualityServed:
+            Le "That's a lot of mango ice cream, [player_name]!"
+            c "You said you were hungry, so I added a bit extra."
+            Le "Thanks a ton! I really needed some extra ice cream today!"
+            $ evalCustomerScore += 1
+    
+    hide leymas with easeoutleft #Add a bit more here possibly. Idk why I like leymas more than the other characters I made up
+    m "With that, Leymas paid and left."
 
-        $ evalServedCustomers += 1
-        jump eval_katsu_help
+    $ evalServedCustomers += 1
+    jump eval_katsu_help
 
 label eval_help_oph:
     #chap2storebread is false if you meet her earlier
@@ -839,63 +807,61 @@ label eval_help_oph:
             Op "All of this waiting in line has left me starving!"
     
     c "Well, one scoop of mango ice cream coming right up!"
-    jump eval_katsu_help_2
+    call eval_katsu_help_2 from eval_help_oph_2
+    c "Here's your ice cream!"
 
-    label eval_help_oph_2:
-        c "Here's your ice cream!"
-
-        #This is gonna be fun...
-        if evalCharacterMood == 0:
-            if evalCharacterMood == evalQualityServed:
-                if not chap2storebread:
-                    Op "Thanks for making it quick. I don't know how much longer I could stand before falling over!"
-                else:
-                    Op "Thanks a ton! Now, I should really get going. I've got to put these fruits in the fridge!"
-                $ evalCustomerScore += 1
+    #This is gonna be fun...
+    if evalCharacterMood == 0:
+        if evalCharacterMood == evalQualityServed:
+            if not chap2storebread:
+                Op "Thanks for making it quick. I don't know how much longer I could stand before falling over!"
             else:
-                play sound "fx/impact3.ogg"
-                hide ophinia with easeoutbottom
-                m "As soon as I tried to give the dragon her ice cream, she toppled over."
-                c "Are you alright?"
-                show ophinia normal with easeinbottom
-                Op "Perfectly fine! I've just been standing for too long, that's all!"
-                m "She took the ice cream from my hand like nothing had happened."
-                Op "Thanks for the ice cream!"
-                if chap2storebread:
-                    m "How did her fruits not fall out of the box?"
-        elif evalCharacterMood == 1:
-            if evalCharacterMood == evalQualityServed:
-                Op "Wow, this looks absolutely stunning! Thank you!"
-                $ evalCustomerScore += 1
-            elif evalQualityServed == 0:
-                if chap2storebread:
-                    Op "Maybe I made the wrong decision. This doesn't look as good as the other flavors any more."
-                    c "Looks can be deceiving."
-                    Op "You're right! Like this box on my head makes me look crazy, but in reality I'm perfectly sane!"
-                    m "I'm not so sure about that."
-                else:
-                    Op "Hmm... This doesn't look as good as the other flavors any more."
-                    c "Would you like to change your order?"
-                    Op "No. No. How would I ever choose?"
-            else:
-                Op "That is a lot of ice cream. No way this will all fit in my stomach!"
+                Op "Thanks a ton! Now, I should really get going. I've got to put these fruits in the fridge!"
+            $ evalCustomerScore += 1
         else:
-            if evalCharacterMood == evalQualityServed:
-                Op "That's a lot of ice cream! Thanks a ton!"
-                $ evalCustomerScore += 1
+            play sound "fx/impact3.ogg"
+            hide ophinia with easeoutbottom
+            m "As soon as I tried to give the dragon her ice cream, she toppled over."
+            c "Are you alright?"
+            show ophinia normal with easeinbottom
+            Op "Perfectly fine! I've just been standing for too long, that's all!"
+            m "She took the ice cream from my hand like nothing had happened."
+            Op "Thanks for the ice cream!"
+            if chap2storebread:
+                m "How did her fruits not fall out of the box?"
+    elif evalCharacterMood == 1:
+        if evalCharacterMood == evalQualityServed:
+            Op "Wow, this looks absolutely stunning! Thank you!"
+            $ evalCustomerScore += 1
+        elif evalQualityServed == 0:
+            if chap2storebread:
+                Op "Maybe I made the wrong decision. This doesn't look as good as the other flavors any more."
+                c "Looks can be deceiving."
+                Op "You're right! Like this box on my head makes me look crazy, but in reality I'm perfectly sane!"
+                m "I'm not so sure about that."
             else:
-                Op "That looks so good!"
-                Op "I might just have to wait in line another time to get more!" #Do I actually have here come back? Hell yeah lol
-                c "I could just give you a bit more now."
-                Op "No, it's okay. I'll wait."
-                $ evalOphSeconds = True
-        
-        hide ophinia with easeoutleft
-        m "With that, she paid and left."
+                Op "Hmm... This doesn't look as good as the other flavors any more."
+                c "Would you like to change your order?"
+                Op "No. No. How would I ever choose?"
+        else:
+            Op "That is a lot of ice cream. No way this will all fit in my stomach!"
+    else:
+        if evalCharacterMood == evalQualityServed:
+            Op "That's a lot of ice cream! Thanks a ton!"
+            $ evalCustomerScore += 1
+        else:
+            Op "That looks so good!"
+            Op "I might just have to wait in line another time to get more!" #Do I actually have here come back? Hell yeah lol
+            c "I could just give you a bit more now."
+            Op "No, it's okay. I'll wait."
+            $ evalOphSeconds = True
+    
+    hide ophinia with easeoutleft
+    m "With that, she paid and left."
 
-        $ evalServedCustomers += 1
-        $ evalOphPosition = evalServedCustomers
-        jump eval_katsu_help
+    $ evalServedCustomers += 1
+    $ evalOphPosition = evalServedCustomers
+    jump eval_katsu_help
 
 label eval_help_luc:
     $ evalCharacterPreferredFlavor = "the special"
@@ -934,58 +900,56 @@ label eval_help_luc:
     if mp.fish:
         m "Oh no, I think I might know what the special is referring to."
     c "Well then, one special coming right up!"
-    jump eval_katsu_help_2
-
-    label eval_help_luc_2:
-        c "Here's your 'special' scoop of ice cream. I hope it's good!"
-        
-        if evalCharacterMood == 0:
-            if evalCharacterMood == evalQualityServed:
-                Lu "Thank you for making it quickly!"
-                c "Happy to help. I hate being late myself."
-                $ evalCustomerScore += 1
-            else:
-                Lu "Thank you! I've really, really got to go now."
-        elif evalCharacterMood == 1:
-            if evalCharacterMood == evalQualityServed:
-                Lu "Wow, this looks awesome!"
-                c "I had Katsuharu take special care in making your 'special' scoop."
-                Lu "Very funny, [player_name]."
-                c "Thank you! I pride myself in my humor."
-                Lu "With jokes like that, I'd be worried."
-                $ evalCustomerScore += 1
-            elif evalQualityServed == 0:
-                Lu "Thanks, but it looks a bit different from what I'm used to."
-                c "Maybe because it's a 'special' flavor?"
-                Lu "I don't think that's it. It just looks a bit... Off."
-                c "Would you like another?"
-                Lu "Don't worry about it. I shouldn't judge a book by it's cover."
-            else:
-                Lu "No way I'm going to be able to eat a scoop of ice cream that big in one sitting! Thanks, though!"
+    call eval_katsu_help_2 from eval_help_luc_2
+    c "Here's your 'special' scoop of ice cream. I hope it's good!"
+    
+    if evalCharacterMood == 0:
+        if evalCharacterMood == evalQualityServed:
+            Lu "Thank you for making it quickly!"
+            c "Happy to help. I hate being late myself."
+            $ evalCustomerScore += 1
         else:
-            if evalCharacterMood == evalQualityServed:
-                Lu "Wow! I'm so glad I asked for a bit more. That looks perfect!"
-                $ evalCustomerScore += 1
-            else:
-                Lu "I can't wait to try this new flavor! Although it already looks so good, I'm wondering if I should have ordered another."
-                c "You still could."
-                Lu "I shouldn't hold up the line any longer."
-        
-        m "The dragon then took a quick taste of the 'special'."
-        if mp.fish:
-            m "I was quite interested to see if something like that fish I had could possibly be good as ice cream."
+            Lu "Thank you! I've really, really got to go now."
+    elif evalCharacterMood == 1:
+        if evalCharacterMood == evalQualityServed:
+            Lu "Wow, this looks awesome!"
+            c "I had Katsuharu take special care in making your 'special' scoop."
+            Lu "Very funny, [player_name]."
+            c "Thank you! I pride myself in my humor."
+            Lu "With jokes like that, I'd be worried."
+            $ evalCustomerScore += 1
+        elif evalQualityServed == 0:
+            Lu "Thanks, but it looks a bit different from what I'm used to."
+            c "Maybe because it's a 'special' flavor?"
+            Lu "I don't think that's it. It just looks a bit... Off."
+            c "Would you like another?"
+            Lu "Don't worry about it. I shouldn't judge a book by it's cover."
         else:
-            m "I was quite interested to see if the 'special' was any good."
-        m "He flicked his tongue on the side of the scoop and smacked his lips a few times."
-        Lu "Wow! This really is something special!"
-        c "Is it good?"
-        Lu "It's delicious, but I have no clue how to describe the flavor."
-        c "Interesting."
-        hide lucius with easeoutleft
-        m "With that, he paid and left."
+            Lu "No way I'm going to be able to eat a scoop of ice cream that big in one sitting! Thanks, though!"
+    else:
+        if evalCharacterMood == evalQualityServed:
+            Lu "Wow! I'm so glad I asked for a bit more. That looks perfect!"
+            $ evalCustomerScore += 1
+        else:
+            Lu "I can't wait to try this new flavor! Although it already looks so good, I'm wondering if I should have ordered another."
+            c "You still could."
+            Lu "I shouldn't hold up the line any longer."
+    
+    m "The dragon then took a quick taste of the 'special'."
+    if mp.fish:
+        m "I was quite interested to see if something like that fish I had could possibly be good as ice cream."
+    else:
+        m "I was quite interested to see if the 'special' was any good."
+    m "He flicked his tongue on the side of the scoop and smacked his lips a few times."
+    Lu "Wow! This really is something special!"
+    c "Is it good?"
+    Lu "It's delicious, but I have no clue how to describe the flavor."
+    c "Interesting."
+    hide lucius with easeoutleft
+    m "With that, he paid and left."
 
-        $ evalServedCustomers += 1
-        jump eval_katsu_help
+    $ evalServedCustomers += 1
+    jump eval_katsu_help
 
 label eval_help_xith:
     $ evalCharacterPreferredFlavor = "cherry"
@@ -1011,77 +975,75 @@ label eval_help_xith:
     c "Alright then, what can I get you?"
     Xi "I usually have the vanilla, but I think I want to spice it up a little today. How about I get the cherry instead?"
     c "Sure thing!"
-    jump eval_katsu_help_2
+    call eval_katsu_help_2 from eval_help_xith_2
+    c "Here's the cherry ice cream you asked for!"
 
-    label eval_help_xith_2:
-        c "Here's the cherry ice cream you asked for!"
-
-        if evalCharacterMood == 0:
-            if evalCharacterMood == evalQualityServed:
-                Xi "Ah, thanks for making it quick."
-                c "Of course. Can't let you be late."
-                $ evalCustomerScore += 1
-            else:
-                Xi "Looks spectacular, but I've go to go to make it to my appointment on time."
-                $ evalXithReporter = False
-        elif evalCharacterMood == 1:
-            if evalCharacterMood == evalQualityServed:
-                Xi "This is quite a stunning specimen of ice cream!"
-                c "Thank Katsuharu. He gave this one a bit of extra love."
-                Xi "I can tell."
-                $ evalCustomerScore += 1
-            elif evalQualityServed == 0:
-                Xi "It looks good, but Katsuharu might be losing his touch."
-                c "Is everything alright?"
-                Xi "Oh yes. I just have a bad habit of judging foods at face value without trying them."
-            else:
-                Xi "Did you give me an ice cream scoop or an ice cream mountain?"
-                c "I did add a bit extra to it."
-                Xi "I can tell! No way my stomach can fit all of this!"
+    if evalCharacterMood == 0:
+        if evalCharacterMood == evalQualityServed:
+            Xi "Ah, thanks for making it quick."
+            c "Of course. Can't let you be late."
+            $ evalCustomerScore += 1
         else:
-            if evalCharacterMood == evalQualityServed:
-                Xi "That's not just an ice cream scoop. That's an ice cream mountain."
-                Xi "I'm so hungry, too. Thanks!"
-                $ evalCustomerScore += 1
-            else:
-                Xi "Damn, I should have requested more ice cream."
-                c "You still could if you want."
-                Xi "I think I'll have to pass. I should be cutting back on my sugar intake anyways."
-        
-        if evalXithReporter:
-            $ renpy.pause (0.5)
-            Xi "You know, I'm actually a reporter."
-            c "Really?"
-            Xi "Yeah, I came here for the inside {i}scoop{/i} on things."
-            c "Did you make that up just to make that joke?"
-            Xi "That would be pretty clever, but no."
-            Xi "I write articles for the local paper."
-            c "Interesting. Is there a lot to write about?"
-            Xi "There's always the small stuff, like recent achievements of the locals or new stores, but usually nothing interesting."
-            c "Have you written anything on the events that just took place?"
-            Xi "I would love to, but the council wouldn't let me have access to any of the archives."
-            Xi "Therefore, I have nothing to base my writing on."
-            c "That's too bad."
-            Xi "I was actually wondering if you would be willing to answer a few questions for me."
-            c "Sorry, but not at the moment. I have a pretty packed schedule today."
-            Xi "Of course not right now, but maybe another time?"
+            Xi "Looks spectacular, but I've go to go to make it to my appointment on time."
+            $ evalXithReporter = False
+    elif evalCharacterMood == 1:
+        if evalCharacterMood == evalQualityServed:
+            Xi "This is quite a stunning specimen of ice cream!"
+            c "Thank Katsuharu. He gave this one a bit of extra love."
+            Xi "I can tell."
+            $ evalCustomerScore += 1
+        elif evalQualityServed == 0:
+            Xi "It looks good, but Katsuharu might be losing his touch."
+            c "Is everything alright?"
+            Xi "Oh yes. I just have a bad habit of judging foods at face value without trying them."
+        else:
+            Xi "Did you give me an ice cream scoop or an ice cream mountain?"
+            c "I did add a bit extra to it."
+            Xi "I can tell! No way my stomach can fit all of this!"
+    else:
+        if evalCharacterMood == evalQualityServed:
+            Xi "That's not just an ice cream scoop. That's an ice cream mountain."
+            Xi "I'm so hungry, too. Thanks!"
+            $ evalCustomerScore += 1
+        else:
+            Xi "Damn, I should have requested more ice cream."
+            c "You still could if you want."
+            Xi "I think I'll have to pass. I should be cutting back on my sugar intake anyways."
+    
+    if evalXithReporter:
+        $ renpy.pause (0.5)
+        Xi "You know, I'm actually a reporter."
+        c "Really?"
+        Xi "Yeah, I came here for the inside {i}scoop{/i} on things."
+        c "Did you make that up just to make that joke?"
+        Xi "That would be pretty clever, but no."
+        Xi "I write articles for the local paper."
+        c "Interesting. Is there a lot to write about?"
+        Xi "There's always the small stuff, like recent achievements of the locals or new stores, but usually nothing interesting."
+        c "Have you written anything on the events that just took place?"
+        Xi "I would love to, but the council wouldn't let me have access to any of the archives."
+        Xi "Therefore, I have nothing to base my writing on."
+        c "That's too bad."
+        Xi "I was actually wondering if you would be willing to answer a few questions for me."
+        c "Sorry, but not at the moment. I have a pretty packed schedule today."
+        Xi "Of course not right now, but maybe another time?"
 
-            menu:
-                "Sure.":
-                    c "Sure. I'd love to help you!"
-                    Xi "Really? Thanks..."
-                    c "It's [player_name]."
-                    Xi "Oh, thanks [player_name]. I'm Xith."
-                    c "Nice to meet your acquaintance."
-                    $ evalHelpXith = True
-                "I don't want to think about that quite yet.":
-                    c "Sorry, but I really don't want to think about those events yet. They still make me uneasy."
-                    Xi "I understand. Well, thanks for the ice cream!"
-        
-        hide xith with easeoutleft
-        m "With that, he paid and left."
+        menu:
+            "Sure.":
+                c "Sure. I'd love to help you!"
+                Xi "Really? Thanks..."
+                c "It's [player_name]."
+                Xi "Oh, thanks [player_name]. I'm Xith."
+                c "Nice to meet your acquaintance."
+                $ evalHelpXith = True
+            "I don't want to think about that quite yet.":
+                c "Sorry, but I really don't want to think about those events yet. They still make me uneasy."
+                Xi "I understand. Well, thanks for the ice cream!"
+    
+    hide xith with easeoutleft
+    m "With that, he paid and left."
 
-        $ evalServedCustomers += 1
-        jump eval_katsu_help
+    $ evalServedCustomers += 1
+    jump eval_katsu_help
 
 #I'M DONE!!!!!!!!!!!! YES!!!!!!!!!!!!

--- a/eval_tdomi_remy.rpy
+++ b/eval_tdomi_remy.rpy
@@ -171,10 +171,7 @@ label eval_tdomi_remy:
             c "As a little hatchling, I'm sure that Amely would love to go and get some ice cream, and Adine has done so much for the both of us."
             Ry smile "It's been ages since I've had the opportunity to sit down and have a little get-together with everyone."
             Ry normal "Work, especially since Reza, has been particularly chaotic. It would be nice for the four of us to have a nice day out."
-            if evalDoingSecretEnding:
-                c "Couldn't agree more. I've been so busy in the last few months, I feel like I've missed out on so much."
-            else:
-                 "Couldn't agree more. Being in a coma for the last few months, I feel like I've missed out on so much."
+            c "Couldn't agree more. Being in a coma for the last few months, I feel like I've missed out on so much."
             c "It would be nice to talk over some nice ice cream."
             Ry look "Hmmm... We may have to wait a little bit, Adine is probably busy on her shift delivering food."
             c "Good point..."
@@ -197,6 +194,8 @@ label eval_tdomi_remy:
                     c "How about a nice walk around the area?"
                     Ry look "You really think that walking is more interesting than taking care of children?"
                     c "It beats the yelling and screaming."
+                    $ evalRemyStatus=remystatus#store remy's original status
+                    $ remystatus="bad"#having Remy's status change to bad can add a punch to the gut
                     Ry angry "You know what? Taking a simple walk sounds like a pretty boring day out together. I think I'd rather go to the orphanage by myself."
                     hide remy with dissolvemed
                     stop music fadeout 2.0
@@ -204,7 +203,7 @@ label eval_tdomi_remy:
                     m "The dragon stormed off and prepared to fly over to the orphanage."
                     
                     menu:
-                        "Stop Remy.":
+                        "[[Stop Remy]":
                             c "Wait! Remy!"
                             play sound "fx/evalgrasswalk2"
                             m "Remy looked at me and walked back over."
@@ -213,6 +212,7 @@ label eval_tdomi_remy:
                             Ry "What?"
                             play music "mx/jazzy.ogg"
                             c "I'm sorry, you're right. It was extremely selfish of me to prioritize my own enjoyment over that of yours and the childrens'."
+                            $ remystatus=evalRemyStatus#you were quick to apolgize for your rash decision and his mood is restored
                             Ry normal "I'm glad to hear that. I was worried for a second that you really were just that unkind."
                             c "No, I think I just overreacted. Human children can be a complete nightmare sometimes."
                             Ry "Well, so can dragon children, but you just learn to accept that they haven't had as much time on the planet as us, and sometimes have difficulty expressing their emotions in other ways."
@@ -222,7 +222,7 @@ label eval_tdomi_remy:
                             Ry normal "Great, we can start making our way over there now!"
                             jump eval_trip_to_orphanage
                         
-                        "Let him leave.":
+                        "[[Let him leave]":
                             play sound "fx/takeoff.ogg"
                             m "I silently watched as Remy extended his wings and flew off to the orphanage."
                             "???" "You are an idiot"
@@ -267,6 +267,8 @@ label eval_tdomi_remy:
                     c "How about a nice walk around the area?"
                     Ry look "You really think that walking is more interesting than taking care of children?"
                     c "It beats the yelling and screaming."
+                    $ evalRemyStatus=remystatus#store remy's original status
+                    $ remystatus="bad"#having Remy's status change to bad can add a punch to the gut
                     Ry angry "You know what? Taking a simple walk sounds like a pretty boring day out together. I think I'd rather go to the orphanage by myself."
                     hide remy with dissolvemed
                     stop music fadeout 2.0
@@ -274,7 +276,7 @@ label eval_tdomi_remy:
                     m "The dragon stormed off and prepared to fly over to the orphanage."
                     
                     menu:
-                        "Stop Remy.":
+                        "[[Stop Remy]":
                             c "Wait! Remy!"
                             play sound "fx/evalgrasswalk2"
                             m "Remy looked at me and walked back over."
@@ -283,6 +285,7 @@ label eval_tdomi_remy:
                             Ry "What?"
                             play music "mx/jazzy.ogg"
                             c "I'm sorry, you're right. It was extremely selfish of me to prioritize my own enjoyment over that of yours and the childrens'."
+                            $ remystatus=evalRemyStatus#you were quick to apolgize for your rash decision and his mood is restored
                             Ry normal "I'm glad to hear that. I was worried for a second that you really were just that unkind."
                             c "No, I think I just overreacted. Human children can be a complete nightmare sometimes."
                             Ry "Well, so can dragon children, but you just learn to accept that they haven't had as much time on the planet as us, and sometimes have difficulty expressing their emotions in other ways."
@@ -292,7 +295,7 @@ label eval_tdomi_remy:
                             Ry normal "Great, we can start making our way over there now!"
                             jump eval_trip_to_orphanage
                         
-                        "Let him leave.":
+                        "[[Let him leave]":
                             play sound "fx/takeoff.ogg"
                             m "I silently watched as Remy extended his wings and flew off to the orphanage."
                             "???" "You are an idiot"
@@ -305,8 +308,7 @@ label eval_tdomi_remy:
                             "!!!" "That's what I thought!"
                             $ renpy.pause (0.5)
                             scene black with dissolveslow
-                            c "At a loss for words, I made my way back home, crawled into bed, and did nothing for the rest of the day."
-                            m "Nice one."
+                            m "At a loss for words, I made my way back home, crawled into bed, and spend the rest of the day wondering what possessed me to be so selfish"
                             return
 
 label eval_trip_to_orphanage:
@@ -1714,10 +1716,10 @@ label eval_remy_amely_adine_1: #Ending where "everyone" is here! Totally everyon
     c "I'll get you back for this, Remy."
     Ry "I'm sure you will."
     m "I spotted Adine and Amely walking over to us."
-    hide remy with dissolvemed
-    show remy normal at right with dissolvemed
-    show amely smnormal flip at left with dissolvemed
-    show adine normal b flip behind amely at left with dissolvemed
+    show remy normal at right with move
+    show amely smnormal flip at left
+    show adine normal b flip behind amely at left
+    with easeinleft
     Ad "Took you guys long enough to get here."
     Ad "I don't suppose you had a bit of fun did you?"
     m "My face, just about to return to it's normal shade, became bright red once again."
@@ -1753,14 +1755,12 @@ label eval_remy_amely_adine_1: #Ending where "everyone" is here! Totally everyon
     Am "Ice cream?"
     Ry "I almost forgot about the ice cream! We should probably go before Katsuharu closes up for the day."
     scene black with dissolveslow
-    hide amely with dissolvemed
-    hide remy with dissolvemed
-    hide adine with dissolvemed
     m "We made our way to the end of the line of dragons I had seen earlier."
     scene town2 with dissolveslow
-    show remy normal at right with dissolvemed
-    show amely smnormal flip at left with dissolvemed
-    show adine normal b flip behind amely at left with dissolvemed
+    show remy normal at right
+    show amely smnormal flip at left
+    show adine normal b flip behind amely at left
+    with dissolvemed
     Ry "Wow, this is quite an impressive line."
     c "It seems that my advice has paid off for him after all."
     Ry smile "Indeed."
@@ -1795,9 +1795,10 @@ label eval_remy_amely_adine_1: #Ending where "everyone" is here! Totally everyon
             m "Approaching the stand, I caught the attention of Katsuharu. He waved and beckoned us to come."
     
     scene town7 with dissolveslow
-    show amely smnormal at right with dissolvemed
-    show remy normal behind amely at right with dissolvemed
-    show adine normal b behind remy at Position (xpos=0.6) with dissolvemed
+    show amely smnormal at right
+    show remy normal behind amely at right
+    show adine normal b behind remy at Position (xpos=0.6)
+    with dissolvemed
     show katsu normal flip at Position (xpos=0.1) with easeinleft
 
     Ka "Well, if it isn't the business saving human, [player_name]! Have you come to take up my offer?"
@@ -2142,14 +2143,15 @@ label eval_remy_amely_adine_3:
     Ka smile flip "There's something wrong with your ice cream, let me fix it quickly."
     c "Sure. I'll meet you guys there."
     Ry smile "Alright."
-    show amely smnormal flip with dissolvemed
+    show amely smnormal flip
     hide amely with easeoutright
-    show remy smile flip with dissolvemed
+    show remy smile flip
     hide remy with easeoutright
-    show adine normal b flip with dissolvemed
+    show adine normal b flip
     hide adine with easeoutright
     hide katsu with dissolvemed
-    show katsu normal with dissolvemed
+    show katsu at center with ease
+    show katsu normal
     Ka "I wanted to speak privately with you for a moment, [player_name]."
     c "What about?"
     Ka exhausted "Well, it's about my business. If today has taught me anything, it's that I can't do this alone anymore."
@@ -2194,7 +2196,7 @@ label eval_remy_amely_adine_3:
     hide katsu with easeoutleft
     $ renpy.pause (2.0)
     show katsu normal flip with easeinleft
-    show katsu normal with dissolvemed
+    show katsu normal
     Ka "Here you go."
     c "This one somehow looks even better than the last."
     Ka smile "Thank you!"
@@ -2209,13 +2211,14 @@ label eval_remy_amely_adine_3:
     scene black with dissolveslow
     m "I walked over to where Remy, Adine, and Amely were sitting."
     scene evalpark1 with dissolveslow
-    show amely smnormal at right with dissolvemed
-    show remy normal at right behind amely with dissolvemed
-    show adine normal b flip at left with dissolvemed
+    show amely smnormal at right
+    show remy normal at right behind amely
+    show adine normal b flip at left
+    with dissolvemed
     Ry smile "Sorry, [player_name]. You took so long we had to start eating our ice cream before it all melted!"
     c "No worries. Katsuharu took a bit of time remaking my ice cream."
     Ad "Well it shows. That looks like a perfect scoop of ice cream!"
-    c "It looks so good I almost don't wnat to eat it."
+    c "It looks so good I almost don't want to eat it."
     Ad giggle b flip "Well, you probably should before it melts."
     c "Good point."
     show adine normal b flip with dissolvemed
@@ -2240,9 +2243,9 @@ label eval_remy_amely_adine_3:
         Ad normal b flip "I had a lot of fun today."
         Ry smile "I guess the ice cream was more of a bonus rather than an end goal."
         Ka "Did I hear an unhappy customer?"
-        hide adine with dissolvemed
-        show adine normal b at Position (xpos=0.6) behind remy with dissolvemed
-        show remy normal at right behind amely with dissolvemed
+        show adine normal b flip at Position (xpos=0.6) behind remy with move
+        show adine normal b at Position (xpos=0.6) behind remy
+        show remy normal at right behind amely with move
         show katsu normal flip with easeinleft
         c "How did you know?"
         Ka smile "I have a sixth sense for customer satisfaction."
@@ -2513,6 +2516,7 @@ label eval_remy_amely_adine_sleep_select:
                     c "Goodnight, Remy."
                 stop music fadeout 2.0
                 $ persistent.evalSecretEndingUnlocked = True
+                return
 
             else:
                 c "Why don't we get ready for bed now?"

--- a/eval_tdomi_remy.rpy
+++ b/eval_tdomi_remy.rpy
@@ -1853,7 +1853,7 @@ label eval_remy_amely_adine_1: #Ending where "everyone" is here! Totally everyon
             Ry "I guess it's really up to you, [player_name]. This was your idea after all."
     
     menu:
-        "Help out Katsuharu.":
+        "[[Help out Katsuharu]":
             c "You really think I would leave you guys like that? Of course we can help you, Katsuharu."
             show remy normal at right behind amely with dissolvemed
             show adine normal b at Position (xpos=0.6) behind remy with dissolvemed
@@ -1885,20 +1885,22 @@ label eval_remy_amely_adine_1: #Ending where "everyone" is here! Totally everyon
             c "Seems simple enough."
             jump eval_katsu_help_init
 
-        "Enjoy your ice cream alone.":
+        "[[Enjoy your ice cream alone]":
+            $ adinestatus="bad"
+            $ remystatus="bad"
             stop music fadeout 2.0
             if evalHelpOrphanage:
                 c "I think I've already done enough work today helping at the orphanage."
             else:
                 c "That seems like a lot more work than I want to put up with at the moment."
-            
             Ka exhausted flip "I was looking forward to the extra help."
             Ry sad "Oh, I see, [player_name]."
             Am smsad "Ice cream?"
             Ry "Sorry, Amely. I guess not today."
             Am "Awwwwww."
-            show remy sad flip with dissolvemed
-            show amely smsad flip with dissolvemed
+            show remy sad flip
+            show amely smsad flip
+            with dissolvemed
             hide remy with easeoutright
             hide amely with easeoutright
             m "With his head hung low, Remy walked away with Amely."

--- a/eval_tdomi_secret_orphanage.rpy
+++ b/eval_tdomi_secret_orphanage.rpy
@@ -762,7 +762,7 @@ label eval_secret_orphanage_fix_desk:
                     m "She grabbed a long metal desk leg from the pile and returned to me."
                     show vara smnormal with easeinright
                     Vr "Here."
-                    v "Thank you, Vara."
+                    c "Thank you, Vara."
                 play sound "fx/screwin.mp3"
                 m "I quickly replaced the melted desk leg with a new one."
                 jump eval_secret_orphanage_fix_desk

--- a/eval_tmomi_secret_changes.rpy
+++ b/eval_tmomi_secret_changes.rpy
@@ -290,20 +290,17 @@ label eval_remy_ch4_date_change: #This changes up the end of Remy's date to acco
             play sound "fx/fireworks2.ogg"
             Vr smshocked flip "..."
             m "What must have been the finale for the day's firework show seemed to frighten Vara."
-            show vara smshocked at right with move
-            show vara smshocked at right with dissolvemed
+            show vara at right with move
+            show vara smshocked
             Ry "It's alright, Vara. It's just some fireworks."
             Vr "..."
             play sound "fx/hug.mp3"
             m "Remy hugged Vara with his wings, and she seemed to settle down."
             show vara smnormal with dissolvemed
             m "I turned my gaze to face the two dragons."
-            hide remy
-            hide vara
-            with dissolvemed
-            show remy normal behind vara
-            show vara smnormal
-            with dissolvemed
+            show remy normal behind vara at center
+            show vara smnormal at center
+            with move
 
             stop music fadeout 2.0
             $ renpy.pause (3.0)
@@ -378,8 +375,9 @@ label eval_remy_ch4_date_change: #This changes up the end of Remy's date to acco
                         Ry smile "I could keep a closer eye on you as well. What do you say, Vara?"
                         m "Vara nodded."
                         Ry normal "I guess that decides it."
-                        hide remy with dissolvemed
-                        hide vara with dissolvemed
+                        hide remy
+                        hide vara
+                        with dissolvemed
                         m "The three of us made our way into the bedroom."
                         m "Too tired to even take off my clothes, I lay down on the bed."
                         m "Remy removed his tie and rested it on the nightstand."
@@ -749,12 +747,11 @@ label eval_remy_good_ending_change: #And so the contruction of a completely new 
     show izumi normal at right with ease
     As "Stop, Reza."
     play sound "fx/rev.ogg"
-    show reza gunpoint flip
+    show reza gunpoint flip with dissolvemed
     m "Confused, Reza spun around, aiming his gun at the newcomer who was slowly walking towards him."
     Rz "Who the fuck are you? Freeze! I said freeze!"
     show izumi at Position(xpos=0.8, xanchor='center') with ease
     As "Want to waste your bullets on me? Feel free."
-    play sound "fx/rev.ogg"
     Rz gunpoint flip "If you say so."
     play sound "fx/gunshot2.wav"
     $ renpy.pause (0.5)
@@ -990,7 +987,7 @@ label eval_post_secret_remy_meeting:
     c "Oh, what did he have to say?"
     Ry "I think it would be better if he explained himself."
     show remy normal at right with move
-    show maverick normal flip at Position(xpos=0.1) with easeinleft
+    show maverick normal b flip at Position(xpos=0.1) with easeinleft
     Mv "Hello, [player_name]."
     c "Hello, Maverick."
     Mv "Listen, [player_name]. I think I owe you an apology."
@@ -998,19 +995,18 @@ label eval_post_secret_remy_meeting:
     Mv "Trying to impress everyone and get on their good side."
     Mv "I never stopped to think that maybe you were just a nice person."
     Mv "Remy had some things to say about you."
-    Mv scared flip "Some things I'll never forget."
-    Mv normal flip "And I want to give you my sincerest apologies."
+    Mv scared b flip "Some things I'll never forget."
+    Mv normal b flip "And I want to give you my sincerest apologies."
     c "I forgive you, Maverick. I can understand how you felt." #Possible to add a choice here to just deny him
     c "With all of the uncertainty and confusion surrounding that time, distrust was inevitable."
     c "I'm just glad we can put this all behind us and move on."
-    Mv nice flip "Me too, [player_name]."
-    Mv normal flip "I'd love to stick around and chat, but Bryce needs me back at the station."
+    Mv nice b flip "Me too, [player_name]."
+    Mv normal b flip "I'd love to stick around and chat, but Bryce needs me back at the station."
     Ry smile "I'm glad you two were able to settle your differences."
     c "Me too. See you around, Maverick."
-    show maverick normal at Position(xpos=0.1) with dissolvemed
+    show maverick normal b at Position(xpos=0.1) with dissolvemed
     hide maverick with easeoutleft
-    hide remy with dissolvemed
-    show remy normal with dissolvemed
+    show remy normal at center with move
     Ry "What will you do now, [player_name]?"
     c "I could use the portal to return to the day of my arrival. After all, I came here to save our dying city, which is something I failed to do."
     Ry "But you saved us. You saved Vara."

--- a/eval_tmomi_secret_changes.rpy
+++ b/eval_tmomi_secret_changes.rpy
@@ -281,15 +281,16 @@ label eval_remy_ch4_date_change: #This changes up the end of Remy's date to acco
         
         m "We made our way back to the main room."
         scene o3 with dissolveslow
-        show vara smnormal flip at left with dissolvemed
-        show remy normal at right behind vara with dissolvemed
+        show vara smnormal flip at left
+        show remy normal at right behind vara
+        with dissolvemed
         Ry "Well, it's getting to be Vara's bedtime, so we best get going."
         c "I understand."
         if evalVaraMood >= 4:
             play sound "fx/fireworks2.ogg"
             Vr smshocked flip "..."
             m "What must have been the finale for the day's firework show seemed to frighten Vara."
-            hide vara with dissolvemed
+            show vara smshocked at right with move
             show vara smshocked at right with dissolvemed
             Ry "It's alright, Vara. It's just some fireworks."
             Vr "..."
@@ -322,8 +323,9 @@ label eval_remy_ch4_date_change: #This changes up the end of Remy's date to acco
             m "I awoke when I felt a strange pressing senastion on my cheek."
             m "It was Vara, who looked down at me with a concerened expression."
             scene o3 with dissolveslow
-            show remy look with dissolvemed
-            show vara smshocked with dissolvemed
+            show remy look
+            show vara smshocked
+            with dissolvemed
             play music "mx/flashback.ogg"
             Vr "..."
             c "Ugh, how long was I out for?"
@@ -802,9 +804,7 @@ label eval_remy_good_ending_change: #And so the contruction of a completely new 
     play sound "fx/impact3.ogg"
     m "He pulled the trigger a second time, and I heard a dull thud come from the bushes."
     m "Suddenly, a flurry of gray rushed at Reza."
-    show maverick angry flip at left with easeinleft
-    $ renpy.pause (1.0)
-    show maverick at Position(xpos=0.65, xanchor='center') with move6
+    show maverick angry flip at Position(xpos=0.65, xanchor='center') with easeinleft
     play sound "fx/impact3.ogg"
     show maverick at Position(xpos=0.8, xanchor='center', ypos=1.0, yanchor="top")
     show reza at Position(xpos=1.0, xanchor='center', ypos=1.0, yanchor="top")
@@ -882,7 +882,10 @@ label eval_remy_good_ending_change: #And so the contruction of a completely new 
     show vara smsad flip behind remy at Position(xpos=-0.1) with move
     m "Vara snuggled closer to Remy and buried her face in his side."
     m "Suddenly, the Administrator appeared next to me."
-    show izumi normal 4 d at Position (xpos=0.9) with easeinright
+    if persistent.annabadending==True:
+        show izumi normal 4 d at Position(xpos=0.9) with easeinright
+    else:
+        show izumi normal 4 c at Position(xpos=0.9) with easeinright
     As "This is not right."
     c "What do you mean?"
     show vara smgrowl flip at Position(xpos=-0.1) with dissolvemed
@@ -926,7 +929,10 @@ label eval_remy_good_ending_change: #And so the contruction of a completely new 
     m "The Administrator suddenly fell to the ground."
     show vara smshocked flip with dissolvemed
     c "Are you okay?"
-    As "You will know what to do, [player_name]."
+    if persistent.annabadending==True:
+        As normal 4 d "You will know what to do, [player_name]."
+    else:
+        As normal 4 c "You will know what to do, [player_name]."
     m "With that, she closed her eyes and her body went limp."
 
     stop music fadeout 3.0
@@ -962,7 +968,7 @@ label eval_remy_good_ending_change: #And so the contruction of a completely new 
     n "After I awoke from my coma, I had to consider my options."
     n "While the dragons were able to create a new power source for the portal, I wouldn't have known how to send myself back to humanity, as their portal was already deactivated - at least not without the expertise of the dead Administrator."
     n "The only coordinates remaining in the portal were those she left as a last resort. It turned out they were to send someone back in time to the day I arrived here."
-    n "As soon as I could, I met with Remy, who told me about everything I had missed."
+    n "I met with Remy as soon as i could, who told me about everything I had missed."#had to change this to avoid clashing with vara survives mod
 
     window hide
     nvl clear


### PR DESCRIPTION
.gitignore:
1. only needs one instance of a filetype

eval_tdomi_katsugame.rpy:
1. can use "call LABEL from RETURN_LABEL" to reduce the number of lines in the file by a lot
2. made Amely run straight across the screen rather than pausing in front for a few frames

eval_tdomi_remy.rpy:
1. no need to reference not being in a coma
2. added something so that Remy's mood in the main screen can turn bad if you say something to make him think you are selfish
3. changed the way hide and show are used to make things smoother
4. added a missing return so the path that unlocks the secret ending actually ends and does not bleed over into another block of code
5. added a thing where Adine and Remy's status instantly turn to bad if you selfishly choose to eat your ice cream alone

eval_tmomi_secret_changes.rpy:
1. changed the way hide and show are used to make things smoother
2. changed the sprite used for Maverick in the tail end of the ending to reflect that Maverick is back on duty